### PR TITLE
control movement by binding keys to actions, not checking each iteration

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -34,6 +34,7 @@ class Game {
   _GameLoop(dt) {
     const max_timestep = 60
     if (dt > max_timestep) dt = max_timestep
+    Keyboard.Update(dt)
     if (this._world) this._world.Update(dt)
   }
 }

--- a/js/interaction.js
+++ b/js/interaction.js
@@ -1,4 +1,8 @@
 class Keyboard {
+  // constructor() {
+  //   this._keybindings = []
+  // }
+
   static Listen(b = true) {
     if (b) {
       Keyboard._keys_down = []
@@ -11,17 +15,43 @@ class Keyboard {
   }
 
   static IsDown(key) {
-    return Keyboard._keys_down.includes(key)
+    return Keyboard._keys_down.includes(key.toLowerCase())
   }
 
   static _HandleKeyDown(e) {
-    if (!Keyboard._keys_down.includes(e.key))
-      Keyboard._keys_down.push(e.key)
+    if (!Keyboard._keys_down.includes(e.key.toLowerCase()))
+      Keyboard._keys_down.push(e.key.toLowerCase())
   }
 
   static _HandleKeyUp(e) {
-    if (Keyboard._keys_down.includes(e.key))
-      Keyboard._keys_down.splice(Keyboard._keys_down.indexOf(e.key), 1)
+    if (Keyboard._keys_down.includes(e.key.toLowerCase()))
+      Keyboard._keys_down.splice(Keyboard._keys_down.indexOf(e.key.toLowerCase()), 1)
+  }
+
+  /*
+   * bind function to keypress
+   */
+  static BindKey(key, callback) {
+    key = key.toLowerCase()
+    if (!this._keybindings) this._keybindings = []
+    // add key if not alrady bound
+    if (!this._keybindings.map(bind => bind.key).includes(key))
+      this._keybindings.push({key: key, actions: []})
+    // bind callback to key
+    const binding = this._keybindings.find(bind => bind.key == key)
+    if (!binding.actions.includes(callback)) binding.actions.push(callback)
+  }
+
+  /*
+   * Update (call functions bound to keys)
+   */
+  static Update(dt) {
+    for (let binding of this._keybindings) {
+      if (Keyboard.IsDown(binding.key)) {
+        for (let callback of binding.actions)
+          callback(dt)
+      }
+    }
   }
 }
 

--- a/js/player.js
+++ b/js/player.js
@@ -32,39 +32,50 @@ class Player extends Movable {
     this._hp_total = 100
     this._hp_current = this._health_total
     this._alive = true
+
+    // bind keys
+    key.BindKey('a', dt => this.MoveLeft(dt))
+    key.BindKey('ArrowLeft', dt => this.MoveLeft(dt))
+    key.BindKey('d', dt => this.MoveRight(dt))
+    key.BindKey('ArrowRight', dt => this.MoveRight(dt))
+    key.BindKey('w', dt => this.Jump(dt))
+    key.BindKey('ArrowUp', dt => this.Jump(dt))
   }
 
   //
   // Update
   //
   Update(dt) {
-    if (key.IsDown('ArrowRight') || key.IsDown('ArrowLeft')) {
-      const dir = key.IsDown('ArrowRight') ? 'right' : 'left'
-      this.Move(dir, dt)
-    } else {
+    if (!this._moved) {
       if (Math.abs(this.vel.x) > 0.0001)
         this.vel.x /= 1 + (this._move_acc - 1) * (dt / 1000)
       else
         this.vel.x = 0
-    }
-    if (key.IsDown('ArrowUp')) {
-      this.Jump(dt)
     }
     // If ground contact => reset jump counter
     if (this.has_ground_contact) this.jump_counter = 0
     // Update Weapon
     this._weapon.Update(dt)
     super.Update(dt)
+    this._moved = false
   }
 
   //
   // Move
   //
   Move(dir, dt) {
+    this._moved = true
     if (!this._alive) return
     this.vel.x += this._move_acc * (dir == 'right' ? 1 : -1) * (dt / 1000)
     if (Math.abs(this.vel.x) > this._move_vel)
       this.vel.x = this._move_vel * (this.vel.x > 0 ? 1 : -1)
+  }
+
+  MoveRight(dt) {
+    this.Move('right', dt)
+  }
+  MoveLeft(dt) {
+    this.Move('left', dt)
   }
 
   //


### PR DESCRIPTION
- added Keyboard.BindKey(key, callback) to Keyboard class
  - usage example: Keybard.BindKey('a', dt => this.MoveLeft(dt))
- added Keyboard.Update() to call all actions bound to pressed keys, is called once per frame